### PR TITLE
Add 24 bin binary to 8 digit BCD conversion for the high-score-cart

### DIFF
--- a/headers/bin2bcd.asm
+++ b/headers/bin2bcd.asm
@@ -1,0 +1,58 @@
+; Routine for packing a 3 byte binary field to a 8 digit BCD format.
+; This 3 byte binary high-score is used by the HSC cart.
+
+; The routine will destroy the input during the conversion.
+
+; 24-bit binary to 8-digit packed BCD
+;
+; Input:
+;   BIN0 = LSB
+;   BIN1
+;   BIN2 = MSB
+;
+; Output:
+;   BCD0 = least significant 2 digits
+;   BCD1
+;   BCD2
+;   BCD3 = most significant 2 digits
+;
+
+_bin2bcd
+        lda #0
+        sta BCD0
+        sta BCD1
+        sta BCD2
+        sta BCD3
+
+        ldx #24
+
+bin2bcdloop
+        asl BIN0 ; Shift leftmost bit to carry
+        rol BIN1
+        rol BIN2
+
+        sed
+
+        lda BCD0 ; Multiply by 2
+        adc BCD0 ; and add carry
+        sta BCD0
+
+        lda BCD1 ; Same to higher digits
+        adc BCD1
+        sta BCD1
+
+        lda BCD2
+        adc BCD2
+        sta BCD2
+
+        lda BCD3
+        adc BCD3
+        sta BCD3
+
+        cld
+
+        dex
+        bne bin2bcdloop
+
+        rts
+

--- a/headers/bin2bcd.h
+++ b/headers/bin2bcd.h
@@ -1,0 +1,20 @@
+// This routine converts a 24 bit binary number
+// to 8 digit bcd format.
+// This is needed for showing previous high scores
+// saved in the high-score-cart.
+
+ramchip unsigned char BCD0; // Least significant
+ramchip unsigned char BCD1;
+ramchip unsigned char BCD2;
+ramchip unsigned char BCD3;
+
+ramchip unsigned char BIN0; // Least significant
+ramchip unsigned char BIN1;
+ramchip unsigned char BIN2;
+
+#include "bin2bcd.asm"
+
+void bin2bcd() {
+    asm("JSR _bin2bcd", 3);
+}
+


### PR DESCRIPTION
I am currently using your high-score-cart.h for implementing the functionality to a new game I am working on. As the score range is 24 bits I did not find a suitable tool in the headers library.

So I wonder if it is ok to share my routine for doing the conversion. It uses the SED mode of the 6502. But other than that it is just a brute force approach.

The reason why I want this functionality is to display the "Hall of Fame" for the five best runs. So I need to turn the binary into decimal digits.